### PR TITLE
firmware-qcom-boot-common: provide virtual/bootbins

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-boot-common.inc
+++ b/recipes-bsp/firmware/firmware-qcom-boot-common.inc
@@ -1,5 +1,7 @@
 # Install NHLOS boot binaries in DEPLOY_DIR
 
+PROVIDES += "virtual/bootbins"
+
 inherit deploy
 
 do_deploy() {


### PR DESCRIPTION
Define a common virtual provider for bootbins, as we will later have multiple recipes providing boot binaries (based on base boards / SoCs).

This is to help creating generic dependencies to the boot firmware recipe.