### PR TITLE
Introduce CDT support

### DIFF
--- a/classes-recipe/image_types_qcom.bbclass
+++ b/classes-recipe/image_types_qcom.bbclass
@@ -48,7 +48,7 @@ create_qcomflash_pkg() {
 
     # partition bins
     for pbin in `find ${DEPLOY_DIR_IMAGE} -type f -name 'gpt_main*.bin' \
-                -o -name 'gpt_backup*.bin' -o -name 'patch*.xml'`; do
+                -o -name 'gpt_backup*.bin' -o -name 'patch*.xml' -o -name 'cdt.bin'`; do
         install -m 0644 ${pbin} .
     done
     # skip BLANK_GPT and WIPE_PARTITIONS for rawprogram xml files

--- a/recipes-bsp/firmware/firmware-qcom-boot-common.inc
+++ b/recipes-bsp/firmware/firmware-qcom-boot-common.inc
@@ -3,6 +3,9 @@
 S = "${WORKDIR}/sources"
 UNPACKDIR = "${S}"
 
+CDT_FILE ?= ""
+CDT_FILE:qcs6490-rb3gen2-core-kit ?= "cdt_core_kit"
+
 INHIBIT_DEFAULT_DEPS = "1"
 
 do_configure[noexec] = "1"
@@ -16,6 +19,10 @@ do_deploy() {
     find "${UNPACKDIR}/${BOOTBINARIES}" -name '*.fv' -exec install -m 0644 {} ${DEPLOYDIR} \;
     find "${UNPACKDIR}/${BOOTBINARIES}" -name '*.mbn' -exec install -m 0644 {} ${DEPLOYDIR} \;
     find "${UNPACKDIR}/${BOOTBINARIES}" -name '*.melf' -exec install -m 0644 {} ${DEPLOYDIR} \;
+
+    if [ -f "${UNPACKDIR}/${CDT_FILE}.bin" ]; then
+        install -m 0644 ${UNPACKDIR}/${CDT_FILE}.bin ${DEPLOYDIR}/cdt.bin
+    fi
 }
 addtask deploy before do_build after do_install
 

--- a/recipes-bsp/firmware/firmware-qcom-boot-common.inc
+++ b/recipes-bsp/firmware/firmware-qcom-boot-common.inc
@@ -18,3 +18,5 @@ do_deploy() {
     find "${UNPACKDIR}/${BOOTBINARIES}" -name '*.melf' -exec install -m 0644 {} ${DEPLOYDIR} \;
 }
 addtask deploy before do_build after do_install
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-bsp/firmware/firmware-qcom-boot-qcs6490_00005.0.bb
+++ b/recipes-bsp/firmware/firmware-qcom-boot-qcs6490_00005.0.bb
@@ -9,7 +9,10 @@ FW_BUILD_ID = "r1.0_${PV}/qcm6490-le-1-0"
 FW_BIN_PATH = "common/build/ufs/bin"
 BOOTBINARIES = "QCM6490_bootbinaries"
 
-SRC_URI = "https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip"
-SRC_URI[sha256sum] = "5e597229af9103cfea5b398c7e83a05dd078a18af010a40f1b9adf92967d4c1e"
+SRC_URI = "https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip;name=bootbinaries"
+SRC_URI[bootbinaries.sha256sum] = "5e597229af9103cfea5b398c7e83a05dd078a18af010a40f1b9adf92967d4c1e"
+
+SRC_URI:append:qcs6490-rb3gen2-core-kit = " https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS6490/cdt/rb3gen2-core-kit.zip;downloadfilename=cdt-rb3gen2-core-kit_${PV}.zip;name=rb3gen2-core-kit"
+SRC_URI[rb3gen2-core-kit.sha256sum] = "0fe1c0b4050cf54203203812b2c1f0d9698823d8defc8b6516414a4e5e0c557e"
 
 include firmware-qcom-boot-common.inc

--- a/recipes-bsp/firmware/firmware-qcom-boot-qcs6490_00005.0.bb
+++ b/recipes-bsp/firmware/firmware-qcom-boot-qcs6490_00005.0.bb
@@ -2,6 +2,8 @@ DESCRIPTION = "QCOM NHLOS Firmware for Qualcomm Robotics RB3Gen2 platform"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://${UNPACKDIR}/${BOOTBINARIES}/Qualcomm-Technologies-Inc.-Proprietary;md5=58d50a3d36f27f1a1e6089308a49b403"
 
+COMPATIBLE_MACHINE = "qcm6490"
+
 FW_ARTIFACTORY = "softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_integrationandtest_publictest"
 FW_BUILD_ID = "r1.0_${PV}/qcm6490-le-1-0"
 FW_BIN_PATH = "common/build/ufs/bin"

--- a/recipes-bsp/firmware/firmware-qcom-boot-qcs9100_00006.0.bb
+++ b/recipes-bsp/firmware/firmware-qcom-boot-qcs9100_00006.0.bb
@@ -2,6 +2,8 @@ DESCRIPTION = "QCOM NHLOS Firmware for Qualcomm QCS9100 platform"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://${UNPACKDIR}/${BOOTBINARIES}/Qualcomm-Technologies-Inc.-Proprietary;md5=58d50a3d36f27f1a1e6089308a49b403"
 
+COMPATIBLE_MACHINE = "qcs9100"
+
 FW_ARTIFACTORY = "softwarecenter.qualcomm.com/download/software/chip/qualcomm_linux-spf-1-0/qualcomm-linux-spf-1-0_test_device_integrationandtest_publictest"
 FW_BUILD_ID = "r1.0_${PV}/qcs9100-le-1-0"
 FW_BIN_PATH = "common/build/ufs/bin"

--- a/recipes-bsp/partition/qcom-partition-confs_1.0.bb
+++ b/recipes-bsp/partition/qcom-partition-confs_1.0.bb
@@ -27,6 +27,15 @@ PARTCONF ?= ""
 PARTCONF:qcm6490 ?= "qcm6490-partitions.conf"
 PARTCONF:qcs9100 ?= "qcs9100-partitions.conf"
 
+# For machines with a published cdt file, let's make sure we flash it
+fixup_cdt() {
+    sed -i '/name=cdt/ s/$/ --filename=cdt.bin/' ${S}/${PARTCONF}
+}
+
+do_compile:prepend:qcs6490-rb3gen2-core-kit() {
+    fixup_cdt
+}
+
 do_compile() {
     gen_partition.py -i ${S}/${PARTCONF} -o ${B}/${MACHINE}-partition.xml
 }


### PR DESCRIPTION
It was a bit more convoluted than I wanted.. but here is some initial support for flashing the CDT file.

The CDT file contains some IDs that are used at runtime to identify the board. The CDT is typically flashed in production on the device. However it is possible to erase/corrupt the CDT, which generally bricks the board. 

The CDT is published for some devices, at least all flavor of RB3 Gen2. This PR makes changes in every place where it's needed, so that the generated qcomflash package includes the CDT file, and the rawprogram XML file has the instructions to flash it. 

There are a few tricks in there..
1. The CDT is published in a non-versioned URL. This might be fixed later, for now we use downloadfilename attribute, to mitigate that.
2. the firmware recipes are SOC specific, however the CDT is MACHINE specific, so there is a bit of a dance to make sure that the recipe works for MACHINE with or without CDT, for a given SOC
3. We have been creative with filenames. The CDT file is cdt_xxx_kit.bin, and it's included in a ZIP file called rb3gen2-xxx-kit.zip, so I needed to manage that with variables.