### PR TITLE
workflows: update lava-action to v3

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -160,7 +160,7 @@ jobs:
           cat "${JOB_FILE_NAME}"
           echo "job_file_name=${JOB_FILE_NAME}" >> "${GITHUB_OUTPUT}"
 
-      - uses: foundriesio/lava-action@v2
+      - uses: foundriesio/lava-action@v3
         with:
           lava_token: ${{ secrets.LAVATOKEN }}
           lava_url: 'lava.infra.foundries.io'


### PR DESCRIPTION
This change fixes the issue with parsing incomplete LAVA logs. Example failure can be seen in the nightly build:
https://github.com/qualcomm-linux/meta-qcom-hwe/actions/runs/12531541000/job/34949448452#step:4:821