### PR TITLE
workflows: refactor job and triggers

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -2,10 +2,10 @@ name: Build Yocto
 
 on:
   workflow_call:
-  pull_request:
-  push:
-    branches:
-      - main
+    outputs:
+      artifacts_url:
+        description: "URL to retrieve build artifacts"
+        value: ${{ jobs.create-output.outputs.url }}
 
 env:
   CACHE_DIR: /srv/gh-runners/quic-yocto
@@ -129,41 +129,15 @@ jobs:
 
           echo # new line break in case response doesn't have one
           echo Image available at: ${url}
-  boot-test:
+
+  create-output:
     needs: compile
-    if: github.repository == 'qualcomm-linux/meta-qcom-hwe' && contains(fromJSON('["push", "schedule"]'), github.event_name)
-    strategy:
-      fail-fast: true
-      matrix:
-        machine:
-          - qcs6490-rb3gen2-core-kit
+    outputs:
+      url: ${{ steps.print-output.outputs.url }}
     runs-on: [self-hosted, x86]
-    name: ${{ matrix.machine }}/lava
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Create test job definition
-        id: create_definition
+      - name: "Print output"
+        id: print-output
         run: |
-          export DEVICE_TYPE=${{ matrix.machine }}
-          export BUILD_FILE_NAME="core-image-base-${DEVICE_TYPE}.rootfs.qcomflash.tar.gz"
-          export BUILD_DOWNLOAD_URL="https://quic-yocto-fileserver-1029608027416.us-central1.run.app/${GITHUB_RUN_ID}/${{ matrix.machine }}/${BUILD_FILE_NAME}"
-
-          export JOB_FILE_NAME="${{ matrix.machine }}-${GITHUB_RUN_ID}.yml"
-          sed "s|{{GITHUB_RUN_ID}}|${GITHUB_RUN_ID}|g" ci/lava/${{ matrix.machine }}.yml > "${JOB_FILE_NAME}"
-          sed -i "s|{{GITHUB_SHA}}|${GITHUB_SHA}|g" "${JOB_FILE_NAME}"
-          sed -i "s|{{DEVICE_TYPE}}|${DEVICE_TYPE}|g" "${JOB_FILE_NAME}"
-          sed -i "s|{{BUILD_DOWNLOAD_URL}}|${BUILD_DOWNLOAD_URL}|g" "${JOB_FILE_NAME}"
-          sed -i "s|{{BUILD_FILE_NAME}}|${BUILD_FILE_NAME}|g" "${JOB_FILE_NAME}"
-          cat "${JOB_FILE_NAME}"
-          echo "job_file_name=${JOB_FILE_NAME}" >> "${GITHUB_OUTPUT}"
-
-      - uses: foundriesio/lava-action@v3
-        with:
-          lava_token: ${{ secrets.LAVATOKEN }}
-          lava_url: 'lava.infra.foundries.io'
-          job_definition: ${{ steps.create_definition.outputs.job_file_name }}
-          wait_for_job: 'true'
-          fail_action_on_failure: 'true'
+          echo "Downloads URL: https://quic-yocto-fileserver-1029608027416.us-central1.run.app/${GITHUB_RUN_ID}/"
+          echo "url=\"https://quic-yocto-fileserver-1029608027416.us-central1.run.app/${GITHUB_RUN_ID}/\"" >> $GITHUB_OUTPUT

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -7,6 +7,11 @@ on:
   - cron: "22 1 * * *"   # daily job - pick a random "minute"  - top of hour can be busy in github
 
 jobs:
-  nightly:
+  build-nightly:
     uses: ./.github/workflows/build-yocto.yml
+  test-nightly:
+    uses: ./.github/workflows/test.yml
+    needs: build-nightly
     secrets: inherit
+    with:
+      url: ${{ needs.build-nightly.outputs.artifact_url }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,9 @@
+name: Build on PR
+
+on:
+  pull_request:
+
+jobs:
+  build-pr:
+    uses: ./.github/workflows/build-yocto.yml
+

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,16 @@
+name: Build on push
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-yocto.yml
+  test:
+    uses: ./.github/workflows/test.yml
+    needs: build
+    secrets: inherit
+    with:
+      url: ${{ needs.build.outputs.artifact_url }}

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -1,0 +1,16 @@
+name: Test PR build
+
+on:
+  workflow_run:
+    workflows: ["Build on PR"]
+    types:
+      - completed
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yaml
+    secrets: inherit
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    with:
+      url: ${{ github.event.workflow_run.outputs.artifacts_url }}
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,67 @@
+name: Tests
+
+on:
+  workflow_call:
+    inputs:
+      url:
+        required: true
+        type: string
+
+jobs:
+  prepare-job-list:
+    runs-on: ubuntu-latest
+    outputs:
+      jobmatrix: ${{ steps.listjobs.outputs.jobmatrix }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Print trigger
+        run: |
+          echo "Triggered by ${{ github.event_name }}"
+          echo "Build URL: ${{ inputs.url }}"
+      - name: "List jobs"
+        id: listjobs
+        run: |
+          JOBFILES=$(find ci/lava/ -name *.yaml)
+          JOBFILES=$(echo "$JOBFILES" | sed -e "s/^/\"/" | sed -e "s/$/\",/" | tr -d "\n" | sed -e "s/.$//")
+          JOBFILES="[${JOBFILES}]"
+          J=$(jq -cn --argjson jobfiles "$JOBFILES" '{target: $jobfiles}')
+          echo "jobmatrix=$J" >> $GITHUB_OUTPUT
+          echo "Preparing testjob files"
+
+  submit-job:
+    needs: prepare-job-list
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.retrieve-job-list.outputs.jobmatrix) }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: "Update test definition ${{ matrix.target }}"
+        run: |
+          TARGET=${{ matrix.target }}
+          FIND_PATH="${TARGET#*/}"
+          DEVICE_TYPE="${FIND_PATH%/*}"
+          BUILD_FILE_NAME="core-image-base-${DEVICE_TYPE}.rootfs.qcomflash.tar.gz"
+          BUILD_DOWNLOAD_URL="${{inputs.url}}/${DEVICE_TYPE}/${BUILD_FILE_NAME}"
+          sed -i "s|{{DEVICE_TYPE}}|${DEVICE_TYPE}|g" "${{ matrix.target }}"
+          sed -i "s|{{GITHUB_SHA}}|${GITHUB_SHA}|g" "${{ matrix.target }}"
+          sed -i "s|{{BUILD_DOWNLOAD_URL}}|${BUILD_DOWNLOAD_URL}|g" "${{ matrix.target }}"
+          sed -i "s|{{BUILD_FILE_NAME}}|${BUILD_FILE_NAME}|g" "${{ matrix.target }}"
+          cat "${{ matrix.target }}"
+
+      - name: Submit ${{ matrix.target }}
+        timeout-minutes: 20
+        uses: foundriesio/lava-action@v4
+        with:
+          lava_token: ${{ secrets.LAVATOKEN }}
+          lava_url: 'lava.infra.foundries.io'
+          job_definition: ${{ matrix.target }}
+          wait_for_job: true
+          fail_action_on_failure: true
+          save_result_as_artifact: true

--- a/ci/lava/qcs6490-rb3gen2-core-kit/boot.yaml
+++ b/ci/lava/qcs6490-rb3gen2-core-kit/boot.yaml
@@ -41,7 +41,7 @@ actions:
 - test:
     definitions:
     - from: git
-      name: smoke-test
+      name: "{{DEVICE_TYPE}}-smoke-test"
       path: automated/linux/smoke/smoke.yaml
       repository: https://github.com/linaro/test-definitions.git
       parameters:


### PR DESCRIPTION
This patch splits the build and test workflows into separate files. Both workflows are now reusable. On top of that nightly-build, push and pr workflows are added. These correspond to individual triggers provided by github. Test can now be executed on the PR builds using additional workflow test-pr. This workflow is executed using worflow_run trigger and uses the meta-qcom-hwe repository context so required variables are available.

Fixes: #105