### PR TITLE
Add missing license and copyright declaration needed by repolinter

### DIFF
--- a/classes/linux-qcom-bootimg.bbclass
+++ b/classes/linux-qcom-bootimg.bbclass
@@ -1,3 +1,13 @@
+#
+# Copyright (c) 2015-2023 Linaro
+# Copyright (c) 2016 Matt Madison <matt@madison.systems>
+# Copyright (c) 2017 Artur Mądrzak <artur@madrzak.eu>
+# Copyright (c) 2024 Ola Jeppsson <ola@snap.com>
+# Copyright (c) 2024 Qualcomm Innovation Center, Inc.
+#
+# SPDX-License-Identifier: MIT
+#
+
 QIMG_DEPLOYDIR = "${WORKDIR}/qcom_deploy-${PN}"
 
 # Define INITRAMFS_IMAGE to create kernel+initramfs Android boot images in

--- a/classes/linux-qcom-dtbbin.bbclass
+++ b/classes/linux-qcom-dtbbin.bbclass
@@ -1,4 +1,8 @@
+#
+# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+#
 # SPDX-License-Identifier: BSD-3-Clause-Clear
+#
 
 DTBBIN_DEPLOYDIR = "${WORKDIR}/qcom_dtbbin_deploy-${PN}"
 DTBBIN_SIZE ?= "4096"

--- a/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife/ath10k-generate-board-2_json.sh
+++ b/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife/ath10k-generate-board-2_json.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+#
+# Copyright (c) 2020-2021 Linaro
+#
+# SPDX-License-Identifier: MIT
+#
 
 JSON="$2"
 

--- a/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife/ath10k-generate-pci-board-2_json.sh
+++ b/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife/ath10k-generate-pci-board-2_json.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+#
+# Copyright (c) 2021 Linaro
+#
+# SPDX-License-Identifier: MIT
+#
 
 JSON="$2"
 

--- a/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife/ath11k-generate-ahb-board-2_json.sh
+++ b/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife/ath11k-generate-ahb-board-2_json.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+#
+# Copyright (c) 2024 Linaro
+#
+# SPDX-License-Identifier: MIT
+#
 
 JSON="$2"
 

--- a/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife/ath11k-generate-pci-board-2_json.sh
+++ b/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife/ath11k-generate-pci-board-2_json.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+#
+# Copyright (c) 2024 Linaro
+#
+# SPDX-License-Identifier: MIT
+#
 
 JSON="$2"
 

--- a/recipes-support/fastrpc/fastrpc/mount-dsp.sh
+++ b/recipes-support/fastrpc/fastrpc/mount-dsp.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+#
+# Copyright (c) 2021-2024 Linaro
+#
+# SPDX-License-Identifier: MIT
+#
 
 set -e
 

--- a/recipes-support/initrdscripts/files/copy-modules.sh
+++ b/recipes-support/initrdscripts/files/copy-modules.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Copyright (C) 2022 Linaro Ltd.
-# Licensed on MIT
+# SPDX-License-Identifier: MIT
 
 copy_modules_enabled() {
 	[ -n "${bootparam_copy_modules}" -a -d /lib/modules/`uname -r` ]


### PR DESCRIPTION
Add missing license / copyright declaration on scripts and bbclass files, needed by repolinter (and a standard practice in OE).