### PR TITLE
workflows: add test reporting

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,15 @@ on:
   pull_request:
 
 jobs:
+  event-file:
+    name: "Upload event file"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: Event File
+        path: ${{ github.event_path }}
   build-pr:
     uses: ./.github/workflows/build-yocto.yml
 

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -56,3 +56,33 @@ jobs:
     with:
       url: ${{ needs.retrieve-build-url.outputs.url }}
 
+  publish-test-results:
+    name: "Publish Tests Results"
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Download event file
+        uses: actions/download-artifact@v4
+        with:
+            run-id: ${{ github.event.workflow_run.id }}
+            path: artifacts
+            github-token: ${{ github.token }}
+
+      - name: "List files"
+        run: |
+          echo $GITHUB_WORKSPACE
+          ls -R $GITHUB_WORKSPACE
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "${{ github.workspace }}/artifacts/**/*.xml"
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,3 +67,27 @@ jobs:
           wait_for_job: true
           fail_action_on_failure: true
           save_result_as_artifact: true
+
+  publish-test-results:
+    name: "Publish Tests Results"
+    needs: submit-job
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: "List files"
+        run: |
+          echo $GITHUB_WORKSPACE
+          ls -R $GITHUB_WORKSPACE
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: "${{ github.workspace }}/artifacts/**/*.xml"


### PR DESCRIPTION
This patch adds test reporting action to all workflows that executed testing. Reporiting is using existing action from marketplace: https://github.com/EnricoMi/publish-unit-test-result-action The action uses JUNIT formatted XML files as a base for the test results. PRs that trigger testing will also receive a comment with test result summary.