### PR TITLE
workflows: update job permissions for test reporting

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -6,6 +6,12 @@ on:
   # so that build notification emails will be sent out properly.
   - cron: "22 1 * * *"   # daily job - pick a random "minute"  - top of hour can be busy in github
 
+permissions:
+  checks: write
+  pull-requests: write
+  contents: read
+  packages: read
+
 jobs:
   build-nightly:
     uses: ./.github/workflows/build-yocto.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,12 @@ name: Build on PR
 on:
   pull_request:
 
+permissions:
+  checks: write
+  pull-requests: write
+  contents: read
+  packages: read
+
 jobs:
   event-file:
     name: "Upload event file"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
 
+permissions:
+  checks: write
+  pull-requests: write
+  contents: read
+  packages: read
+
 jobs:
   build:
     uses: ./.github/workflows/build-yocto.yml

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -8,6 +8,12 @@ on:
     types:
       - completed
 
+permissions:
+  checks: write
+  pull-requests: write
+  contents: read
+  packages: read
+
 jobs:
   retrieve-build-url:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Test reporting action requires the following permissions:

  checks: write
  pull-requests: write

This patch adds the required permissions to all jobs that require test reporting. In addition the following permissions are defined:

  contents: read
  packages: read

These are default values set by github, but need to be manually defined to prevent setting them to "none" as per actions documentation.