### PR TITLE
Cdt qcs9100

### DIFF
--- a/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00006.0.bb
+++ b/recipes-bsp/firmware-boot/firmware-qcom-boot-qcs9100_00006.0.bb
@@ -9,7 +9,12 @@ FW_BUILD_ID = "r1.0_${PV}/qcs9100-le-1-0"
 FW_BIN_PATH = "common/build/ufs/bin"
 BOOTBINARIES = "QCS9100_bootbinaries"
 
-SRC_URI = "https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip"
-SRC_URI[sha256sum] = "480682759e27d63b0e44501ae2517b3671bea6dad21071880a22ed5feb5a458b"
+SRC_URI = "https://${FW_ARTIFACTORY}/${FW_BUILD_ID}/${FW_BIN_PATH}/${BOOTBINARIES}.zip;downloadfilename=${BOOTBINARIES}_r1.0_${PV}.zip;name=bootbinaries"
+SRC_URI[bootbinaries.sha256sum] = "480682759e27d63b0e44501ae2517b3671bea6dad21071880a22ed5feb5a458b"
+
+SRC_URI:append:sa8775p-ride-sx = " https://artifacts.codelinaro.org/artifactory/codelinaro-le/Qualcomm_Linux/QCS9100/cdt/ride-sx.zip;downloadfilename=cdt-sa8775p-ride-sx_${PV}.zip;name=sa8775p-ride-sx"
+SRC_URI[sa8775p-ride-sx.sha256sum] = "f5e37d1260627e9d6976827ea5bdc7ffa81c90b7561acfccf24a94bc1313dea5"
+
+CDT_FILE:sa8775p-ride-sx ?= "cdt_ride_sx"
 
 include firmware-qcom-boot-common.inc

--- a/recipes-bsp/partition/qcom-partition-confs_1.0.bb
+++ b/recipes-bsp/partition/qcom-partition-confs_1.0.bb
@@ -36,6 +36,10 @@ do_compile:prepend:qcs6490-rb3gen2-core-kit() {
     fixup_cdt
 }
 
+do_compile:prepend:sa8775p-ride-sx() {
+    fixup_cdt
+}
+
 do_compile() {
     gen_partition.py -i ${S}/${PARTCONF} -o ${B}/${MACHINE}-partition.xml
 }


### PR DESCRIPTION
Add CDT support for QCS9100, like it was done for RB3 Gen2. 
Fixes qualcomm-linux/meta-qcom#706 